### PR TITLE
feat: add signal backtest workflow for line movement and EV

### DIFF
--- a/src/sba/services/backtester.py
+++ b/src/sba/services/backtester.py
@@ -19,6 +19,7 @@ from sba.models.ml.features import (
 )
 from sba.models.ml.xgboost_props import PropPredictionModel
 from sba.models.statistical.kelly import fractional_kelly
+from sba.services.sharp_money import calculate_clv
 
 logger = logging.getLogger(__name__)
 
@@ -346,6 +347,7 @@ class StrategyBacktestResult:
     ending_bankroll: float = 10000.0
     peak_bankroll: float = 10000.0
     equity_curve: list = field(default_factory=list)
+    strategy_breakdown: dict = field(default_factory=dict)
 
 
 def run_backtest(
@@ -516,3 +518,65 @@ def run_backtest(
         peak_bankroll=round(peak, 2),
         equity_curve=equity_curve,
     )
+
+
+def run_signal_backtest(
+    signals: list[dict],
+    strategy_name: str = "Line Movement + EV",
+    min_edge: float = 0.0,
+    min_line_movement: float = 0.0,
+    **kwargs,
+) -> StrategyBacktestResult:
+    """Backtest historical line-movement and +EV signals on a fixed sample.
+
+    Signals should contain normal bet fields plus optional:
+    - ``edge_pct``: expected edge percentage
+    - ``line_movement_pct``: size of line move in percent
+    - ``closing_odds_american``: used to calculate CLV
+    """
+    filtered = [
+        signal
+        for signal in signals
+        if signal.get("edge_pct", 0.0) >= min_edge
+        and abs(signal.get("line_movement_pct", 0.0)) >= min_line_movement
+    ]
+
+    result = run_backtest(filtered, strategy_name=strategy_name, min_edge=min_edge, **kwargs)
+
+    if not filtered:
+        result.strategy_breakdown = {
+            "sample_size": 0,
+            "avg_edge_pct": 0.0,
+            "avg_line_movement_pct": 0.0,
+            "avg_clv_pct": 0.0,
+            "beat_closing_pct": 0.0,
+        }
+        return result
+
+    avg_edge = sum(signal.get("edge_pct", 0.0) for signal in filtered) / len(filtered)
+    avg_line_movement = (
+        sum(abs(signal.get("line_movement_pct", 0.0)) for signal in filtered) / len(filtered)
+    )
+
+    clv_values: list[float] = []
+    beat_closing = 0
+    for signal in filtered:
+        closing_odds = signal.get("closing_odds_american")
+        if closing_odds is None:
+            continue
+        clv = calculate_clv(
+            placed_odds_american=signal.get("odds_american", -110),
+            closing_odds_american=closing_odds,
+        )
+        clv_values.append(clv["clv_percentage"])
+        if clv["beat_closing"]:
+            beat_closing += 1
+
+    result.strategy_breakdown = {
+        "sample_size": len(filtered),
+        "avg_edge_pct": round(avg_edge, 2),
+        "avg_line_movement_pct": round(avg_line_movement, 2),
+        "avg_clv_pct": round(sum(clv_values) / len(clv_values), 2) if clv_values else 0.0,
+        "beat_closing_pct": round((beat_closing / len(clv_values)) * 100, 1) if clv_values else 0.0,
+    }
+    return result

--- a/tests/test_services/test_backtester.py
+++ b/tests/test_services/test_backtester.py
@@ -6,6 +6,7 @@ from sba.services.backtester import (
     Backtester,
     StrategyBacktestResult,
     run_backtest,
+    run_signal_backtest,
     WARMUP_GAMES,
     SIMULATED_ODDS_DECIMAL,
 )
@@ -90,3 +91,58 @@ class TestRunBacktest:
     def test_max_drawdown_non_negative(self):
         result = run_backtest(_bets(5, 5))
         assert result.max_drawdown >= 0
+
+
+class TestRunSignalBacktest:
+    def test_filters_by_edge_and_line_movement(self):
+        result = run_signal_backtest([
+            {
+                "event": "A",
+                "selection": "home",
+                "odds_american": -110,
+                "odds_decimal": 1.91,
+                "closing_odds_american": -120,
+                "edge_pct": 4.5,
+                "line_movement_pct": 3.1,
+                "result": "win",
+            },
+            {
+                "event": "B",
+                "selection": "away",
+                "odds_american": -110,
+                "odds_decimal": 1.91,
+                "closing_odds_american": -105,
+                "edge_pct": 0.5,
+                "line_movement_pct": 0.2,
+                "result": "loss",
+            },
+        ], min_edge=2.0, min_line_movement=1.0)
+        assert result.total_bets == 1
+        assert result.strategy_breakdown["sample_size"] == 1
+
+    def test_calculates_clv_breakdown(self):
+        result = run_signal_backtest([
+            {
+                "event": "A",
+                "selection": "home",
+                "odds_american": -110,
+                "odds_decimal": 1.91,
+                "closing_odds_american": -120,
+                "edge_pct": 5.0,
+                "line_movement_pct": 4.0,
+                "result": "win",
+            },
+            {
+                "event": "B",
+                "selection": "away",
+                "odds_american": 140,
+                "odds_decimal": 2.4,
+                "closing_odds_american": 120,
+                "edge_pct": 6.0,
+                "line_movement_pct": 2.5,
+                "result": "loss",
+            },
+        ], min_edge=2.0, min_line_movement=1.0)
+        assert result.strategy_breakdown["avg_edge_pct"] == 5.5
+        assert result.strategy_breakdown["avg_line_movement_pct"] == 3.25
+        assert result.strategy_breakdown["beat_closing_pct"] == 100.0


### PR DESCRIPTION
## Summary
- add a signal-oriented backtest workflow for line movement and +EV samples
- compute CLV, beat-closing rate, line movement strength, and edge breakdowns
- cover the new workflow with focused backtester tests

## Testing
- python3 -m py_compile src/sba/services/backtester.py
- pytest import is blocked locally by missing pydantic_settings in this environment

Closes #19