### PR TITLE
fix: NameError crash, import order, deprecated types, unused variable

### DIFF
--- a/src/sba/cli/commands/data.py
+++ b/src/sba/cli/commands/data.py
@@ -5,6 +5,7 @@ from rich.console import Console
 
 from sba.config import get_settings
 from sba.data.db import get_connection, init_db
+from sba.data.db.repository import Repository
 from sba.data.sync import DataSyncer
 
 console = Console()

--- a/src/sba/config/settings.py
+++ b/src/sba/config/settings.py
@@ -1,6 +1,5 @@
 from functools import lru_cache
 from pathlib import Path
-from typing import List
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -21,7 +20,7 @@ class Settings(BaseSettings):
     BANKROLL: float = 1000.0
 
     # Sharp bookmakers for consensus probability
-    SHARP_BOOKS: List[str] = ["pinnacle", "circa"]
+    SHARP_BOOKS: list[str] = ["pinnacle", "circa"]
 
     # API rate limits
     ODDS_API_CREDIT_RESERVE: int = 50

--- a/src/sba/data/clients/odds_api.py
+++ b/src/sba/data/clients/odds_api.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from typing import ClassVar
 
 import httpx
 
 from sba.data.clients.base import BaseAPIClient
-
-logger = logging.getLogger(__name__)
 from sba.models.domain import BookmakerOdds, Event, EventOdds, Outcome, Sport
 from sba.utils.odds_math import american_to_decimal, decimal_to_american
+
+logger = logging.getLogger(__name__)
 
 
 class OddsAPIClient(BaseAPIClient):
@@ -160,7 +161,7 @@ class OddsAPIClient(BaseAPIClient):
         return results
 
     # Player prop market keys
-    PROP_MARKETS = [
+    PROP_MARKETS: ClassVar[list[str]] = [
         "player_points", "player_rebounds", "player_assists",
         "player_threes", "player_blocks", "player_steals",
         "player_points_rebounds_assists", "player_points_rebounds",

--- a/src/sba/data/db/connection.py
+++ b/src/sba/data/db/connection.py
@@ -44,12 +44,10 @@ def get_connection():
     Falls back to creating a new connection if the pooled one is stale.
     """
     conn = getattr(_thread_local, "conn", None)
-    reused = False
 
     if conn is not None:
         try:
             conn.execute("SELECT 1")
-            reused = True
         except (sqlite3.ProgrammingError, sqlite3.OperationalError):
             conn = None
 


### PR DESCRIPTION
## Issues fixed

**1. NameError crash in sba data export (F821)**
Repository was used in src/sba/cli/commands/data.py but never imported. Running sba data export raised NameError immediately. Added the missing import from sba.data.db.repository.

**2. Module-level imports placed after logger assignment (E402)**
In src/sba/data/clients/odds_api.py, two imports appeared after logger = logging.getLogger(). Moved them above the logger line.

**3. Mutable class attribute missing ClassVar annotation (RUF012)**
OddsAPIClient.PROP_MARKETS is a mutable list assigned as a bare class attribute. Annotated it as ClassVar[list[str]].

**4. Deprecated typing.List (UP035/UP006)**
src/sba/config/settings.py used typing.List, deprecated since Python 3.9. Replaced with built-in list[str].

**5. Unused variable reused (F841)**
src/sba/data/db/connection.py assigned reused = True but never read the value. Removed the dead assignment.