### PR TITLE
chore: repo hardening (Python CI workflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
Adds a Python CI workflow at `.github/workflows/ci.yml`.

The repo already has a static GitHub Pages deploy workflow, but no CI to validate the Python package on pushes/PRs. This workflow:

- Sets up Python 3.9, 3.11, and 3.12 (matching `requires-python = >=3.9`)
- Installs the package with dev extras (`pip install -e ".[dev]"`)
- Lints with `ruff check .` (ruff config already defined in pyproject.toml)
- Runs the existing test suite with `pytest` (pytest config already defined in pyproject.toml)

Non-breaking and additive: only a new CI file is added; no existing source or logic is modified. All commands map to tooling already configured in `pyproject.toml`.